### PR TITLE
Call digest() with raw=FALSE as xxhash64 did not have raw mode

### DIFF
--- a/R/legacy-checksums.R
+++ b/R/legacy-checksums.R
@@ -136,6 +136,6 @@ checksum_impl_raw <- function(x) {
 
 checksum_impl <- function(x) {
   # this matches the algorithm used in BDS
-  y <- digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = TRUE)
+  y <- digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = FALSE)
   checksum_impl_raw(y)
 }

--- a/tests/testthat/test_legacy-checksums.R
+++ b/tests/testthat/test_legacy-checksums.R
@@ -63,7 +63,7 @@ test_that("update_checksums_data() throws an error if filtering", {
 })
 
 helper_checksum_impl <- function(x) {
-  digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = TRUE)
+  digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = FALSE)
 }
 
 helper_checksum_as_raw <- function(x) {


### PR DESCRIPTION
The next planned version of `digest` expands its use of `raw` mode, thanks largely to a PR made by @pearsonca a year ago.  It turns out that for a number of hashing algorithms, including 'xxhash64' which you use, the value of the `raw` argument did not matter.  We returned character output either way.

But now / in the next version it does, and your tests rely on it in two spots leading to four failure.  They go away if we use the old behavior.  This is demonstrated in the next two paragraphs.

In digest 0.6.37 as on CRAN, raw is indifferent between TRUE or FALSE

```r
> library(digest)
> x <- "the quick brown fox jumped over the fence"
> digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = TRUE)
[1] "0acd1be66972fa22"
> digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = FALSE)
[1] "0acd1be66972fa22"
> packageVersion("digest")
[1] ‘0.6.37’
>
```

In digest as currently in its main branch and a CRAN candidate, it matters

```r
> library(digest)
> x <- "the quick brown fox jumped over the fence"
> digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = TRUE)
[1] 0a cd 1b e6 69 72 fa 22
> digest::digest(x, algo = "xxhash64", serialize = FALSE, raw = FALSE)
[1] "0acd1be66972fa22"
> packageVersion("digest")
[1] ‘0.6.37.2’
>
```

With `raw=FALSE` we get the behaviour your currently rely on, and this PR ensures that. 

Please let me know if this works for you, and if you could possibly update the package at CRAN with the change.